### PR TITLE
Add more padding to team header

### DIFF
--- a/pages/team.js
+++ b/pages/team.js
@@ -58,7 +58,7 @@ export default function About() {
         >
           <Navbar />
           <div className="p-6 text-white flex flex-col items-center text-center mb-20">
-            <h1 className="text-white text-2xl md:text-4xl mt-20 md:mt-16">
+            <h1 className="text-white text-2xl md:text-4xl mt-20 md:mt-16 pt-10 pb-10">
               TEAM
             </h1>
           </div>


### PR DESCRIPTION
Add more top and bottom padding to team header so it doesn't look too tight.
<img width="1673" alt="Screen Shot 2020-09-22 at 12 48 07 AM" src="https://user-images.githubusercontent.com/58486890/93856051-48215400-fc6d-11ea-8d61-31d9ea3097ba.png">
